### PR TITLE
Removed recursion and a few tweaks

### DIFF
--- a/kv-tests.el
+++ b/kv-tests.el
@@ -146,7 +146,14 @@
   (should
    (equal
     '(:a1 value1 :a2 value2)
-    (kvalist->plist '((a1 . value1)(a2 . value2))))))
+    (kvalist->plist '((a1 . value1) (a2 . value2))))))
+
+(ert-deftest kvplist->alist ()
+  "Make plists into alists."
+  (should
+   (equal
+    '((a1 . value1) (a2 . value2))
+    (kvplist->alist '(:a1  value1 :a2 value2)))))
 
 (ert-deftest kvplist->filter-keys ()
   (should

--- a/kv-tests.el
+++ b/kv-tests.el
@@ -141,6 +141,22 @@
     (dotassq 'a.b.c '((a . ((b . ((c . 10)))))))
     10)))
 
+(ert-deftest keyword->symbol ()
+  "Convert keyword into a symbol without the leading `:'"
+  (should
+   (eq
+    'key
+    (keyword->symbol :key)))
+  (should
+   (eq
+    'key
+    (keyword->symbol 'key)))
+  (let ((sym (gensym)))
+    (should
+     (eq
+      sym
+      (keyword->symbol sym)))))
+
 (ert-deftest kvalist->plist ()
   "Make alists into plists."
   (should

--- a/kv.el
+++ b/kv.el
@@ -177,11 +177,9 @@ Converting to a symbol means dropping the :."
 
 The keys are expected to be :prefixed and the colons are removed.
 The keys in the resulting alist are symbols."
-  ;; RECURSION KLAXON
   (when plist
-    (destructuring-bind (key value &rest plist) plist
-      (cons `(,(keyword->symbol key) . ,value)
-            (kvplist->alist plist)))))
+    (loop for (key value . rest) on plist by 'cddr
+	  collect (cons (keyword->symbol key) value))))
 
 (defun kvalist2->plist (alist2)
   "Convert a list of alists too a list of plists."

--- a/kv.el
+++ b/kv.el
@@ -168,7 +168,9 @@ expression is true."
   "A keyword is a symbol leading with a :.
 
 Converting to a symbol means dropping the :."
-  (intern (substring (symbol-name keyword) 1)))
+  (if (keywordp keyword)
+      (intern (substring (symbol-name keyword) 1))
+    keyword))
 
 (defun kvplist->alist (plist)
   "Convert PLIST to an alist.


### PR DESCRIPTION
Hi Nic,

I was playing with kv this afternoon after you reminded me of its existence. There's a nice idiom for stepping through a plist with loop on/by 'cddr. There wasn't a test for kvplist->alist so I added one and in testing I found that keyword->symbol could also act on a non-keyword so I put a check and a test in for that too.

Do what thou wilt and all that!
