### PR TITLE
Use cl-lib package instead of cl package

### DIFF
--- a/kv.el
+++ b/kv.el
@@ -7,6 +7,7 @@
 ;; Version: 0.0.16
 ;; Maintainer: Nic Ferrier <nferrier@ferrier.me.uk>
 ;; Created: 7th September 2012
+;; Package-Requires: ((cl-lib "0.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -30,7 +31,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 
 (defun kvalist->hash (alist &rest hash-table-args)
   "Convert ALIST to a HASH.
@@ -143,7 +144,7 @@ So, for example:
 
 Means: if `a' equals `b', or if `c' equals `d' then the
 expression is true."
-  (flet ((query-parse (query)
+  (cl-flet ((query-parse (query)
            (let ((part (car query))
                  (rest (cdr query)))
              (cond
@@ -404,7 +405,7 @@ FUNC is some sort of `assoc' like function."
 (defmacro kv--destructuring-map (map-function args sequence &rest body)
   "Helper macro for `destructuring-mapcar' and `destructuring-map'."
   (declare (indent 3))
-  (let ((entry (gensym)))
+  (let ((entry (cl-gensym)))
     `(,map-function (lambda (,entry)
                       (destructuring-bind ,args ,entry ,@body))
                     ,sequence)))


### PR DESCRIPTION
This Rull Request replaces `cl` package with `cl-lib` package and replaces `flet` and `gensym` with `cl-flet` and `cl-gensym` respectively.

It removes the following warnings:

```
kv.el:125:31:Warning: `flet' is an obsolete macro (as of 24.3); use either
    `cl-flet' or `cl-letf'.

In kv--destructuring-map:
kv.el:40:8:Warning: function `gensym' from cl package called at runtime
```
