### PR TITLE
Fix for using cl functions

### DIFF
--- a/kv.el
+++ b/kv.el
@@ -30,7 +30,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 
 
 (defun kvalist->hash (alist &rest hash-table-args)


### PR DESCRIPTION
Remove eval-when-compile because this package uses some cl.el functions
gensym and acons.
